### PR TITLE
Fixed width of member-card

### DIFF
--- a/app/Components/Flow5/FirstTwo/About.module.css
+++ b/app/Components/Flow5/FirstTwo/About.module.css
@@ -283,7 +283,7 @@
 
   .cardGrid{
     height: 280px;
-    width: 180px;
+    width: 170px;
   }
 
   .topPara{


### PR DESCRIPTION
Reduced the width of member-card in about page second section, by 10 pixels, ensuring it will be rendered properly on every screen.